### PR TITLE
Use browser natives when bundled with webpack

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,23 @@
+'use strict'
+// ref: https://github.com/tc39/proposal-global
+var getGlobal = function() {
+  // the only reliable means to get the global object is
+  // `Function('return this')()`
+  // However, this causes CSP violations in Chrome apps.
+  if (typeof self !== 'undefined') {
+    return self
+  }
+  if (typeof window !== 'undefined') {
+    return window
+  }
+  if (typeof global !== 'undefined') {
+    return global
+  }
+  throw new Error('unable to locate global object')
+}
+
+var global = getGlobal()
+
+module.exports = exports = global.AbortController
+// Needed for TypeScript and Webpack.
+exports.default = global.AbortController

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "event-target-shim": "^5.0.0"
   },
+  "browser": "./browser.js",
   "devDependencies": {
     "@babel/core": "^7.2.2",
     "@babel/plugin-transform-modules-commonjs": "^7.2.0",


### PR DESCRIPTION
I work on [a library ](https://github.com/Azure/azure-cosmos-js) that depends on node-fetch and abort-controller.  When you bundle my library (and by proxy this library) with webpack it will include polyfills and shims even in browsers that don't need them. Instead by specifying a browser field in package.json you can rely on the browser natives. 

This is basically identical to how node-fetch handles it https://github.com/bitinn/node-fetch/blob/master/browser.js