### PR TITLE
Fixing browser fallback

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -10,4 +10,5 @@ const { AbortController, AbortSignal } =
 
 module.exports = AbortController
 module.exports.AbortSignal = AbortSignal
+module.exports.AbortController = AbortController
 module.exports.default = AbortController


### PR DESCRIPTION
The typescript definitions mention that the package exports `AbortController` as object https://github.com/mysticatea/abort-controller/blob/a935d38e09eb95d6b633a8c42fcceec9969e7b05/dist/abort-controller.d.ts#L43
This PR makes sure that this is also the case for commonjs implementations.